### PR TITLE
Use std::old_io instead of std::io

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,19 +1,19 @@
 extern crate "readline-sys" as ffi;
-use std::io::IoResult;
+use std::old_io::IoResult;
 
 use std::ffi::{CString, c_str_to_bytes};
 use std::str;
 
 pub fn readline(prompt: &str) -> IoResult<String> {
-    use std::io::{IoError, IoErrorKind};
+    use std::old_io::{IoError, IoErrorKind};
     unsafe {
         // It doesn't matter if there is an interior null
-        // It just won't prompt all the way 
-        let line_ptr = 
+        // It just won't prompt all the way
+        let line_ptr =
             ffi::readline(CString::from_slice(prompt.as_bytes()).as_ptr());
 
         if line_ptr.is_null() {
-            return Err(IoError { 
+            return Err(IoError {
                 kind: IoErrorKind::EndOfFile,
                 desc: "end of file",
                 detail: None,


### PR DESCRIPTION
`std::io` was renamed to `std::old_io` in the latest nightly build