### PR TITLE
Update repo links in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,9 +6,9 @@ authors = ["Nicholas Mazzuca <npmazzuca@gmail.com>"]
 
 description = "Wrapper around readline on Linux and Mac OS X, a shim on Windows"
 
-documentation = "https://github.com/GBGamer/readline-sys"
-homepage = "https://github.com/GBGamer/readline-sys"
-repository = "https://github.com/GBGamer/readline-sys"
+documentation = "https://github.com/GBGamer/readline"
+homepage = "https://github.com/GBGamer/readline"
+repository = "https://github.com/GBGamer/readline"
 
 readme = "README.md"
 


### PR DESCRIPTION
The links in Cargo.toml point to `readline-sys`, but the correct repo to point to is `readline`.