### PR TITLE
Make the lib induce less runtime overhead

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "readline"
-version = "0.0.8"
+version = "0.0.9"
 authors = ["Nicholas Mazzuca <npmazzuca@gmail.com>"]
 
 description = "Wrapper around readline on Linux and Mac OS X, a shim on Windows"
@@ -15,4 +15,5 @@ keywords = ["readline", "input"]
 license = "MIT"
 
 [dependencies]
-readline-sys = "0.0.3"
+libc = "*"
+readline-sys = "0.0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,8 +6,6 @@ authors = ["Nicholas Mazzuca <npmazzuca@gmail.com>"]
 
 description = "Wrapper around readline on Linux and Mac OS X, a shim on Windows"
 
-documentation = "https://github.com/GBGamer/readline"
-homepage = "https://github.com/GBGamer/readline"
 repository = "https://github.com/GBGamer/readline"
 
 readme = "README.md"

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,0 +1,40 @@
+use std::ffi::CStr;
+use std::ops;
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+use linux as sys;
+
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+use other as sys;
+
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct Error(());
+
+pub fn error<T>() -> Result<T, Error> { Err(Error(())) }
+
+pub struct ReadlineBytes {
+    inner: sys::ReadlineBytes,
+}
+
+impl ops::Deref for ReadlineBytes {
+    type Target = CStr;
+    fn deref<'a>(&'a self) -> &'a CStr {
+        self.inner.deref()
+    }
+}
+
+pub fn readline_bare(prompt: &CStr) -> Result<ReadlineBytes, Error> {
+    sys::readline_bare(prompt).map(|line| ReadlineBytes { inner: line })
+}
+
+pub fn readline(prompt: &CStr) -> Result<ReadlineBytes, Error> {
+    let maybe_line = readline_bare(prompt);
+    if let Ok(ref line) = maybe_line {
+        add_history(line);
+    }
+    maybe_line
+}
+
+pub fn add_history(line: &CStr) {
+    sys::add_history(line);
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,13 @@
-extern crate "readline-sys" as ffi;
+#![feature(io)]
 
-pub fn readline(prompt: &str) -> Option<String> {
-    ffi::readline(prompt)
-}
+extern crate "readline-sys" as readline_sys;
+extern crate libc;
 
-pub fn add_history(line: &str) {
-    ffi::add_history(line);
-}
+pub use common::Error;
+pub use common::add_history;
+pub use common::readline;
+pub use common::readline_bare;
+
+mod common;
+mod linux;
+mod other;

--- a/src/linux.rs
+++ b/src/linux.rs
@@ -1,0 +1,61 @@
+use common::Error;
+use common::error;
+use libc::c_char;
+use libc::c_void;
+use libc;
+use readline_sys;
+use std::ffi::CStr;
+use std::ops;
+use std::ptr;
+
+#[allow(dead_code)]
+pub struct ReadlineBytes {
+    // The `'static` is a lie, don't expose it.
+    bytes: &'static CStr,
+}
+
+impl ops::Deref for ReadlineBytes {
+    type Target = CStr;
+    fn deref<'a>(&'a self) -> &'a CStr {
+        self.bytes
+    }
+}
+
+impl Drop for ReadlineBytes {
+    fn drop(&mut self) {
+        unsafe { libc::free(self.bytes.as_ptr() as *mut c_void); }
+    }
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+#[allow(dead_code)]
+pub fn readline_bare(prompt: &CStr) -> Result<ReadlineBytes, Error> {
+    unsafe {
+        let bytes: *const c_char =
+            readline_sys::readline(prompt.as_ptr() as *const c_char);
+        if bytes == ptr::null() {
+            return error();
+        }
+        Ok(ReadlineBytes {
+            bytes: CStr::from_ptr(bytes),
+        })
+    }
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+#[allow(dead_code)]
+pub fn readline_bare(prompt: &CStr) -> Result<ReadlineBytes, EndOfFile> {
+    unimplemented!("on this platform");
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+#[allow(dead_code)]
+pub fn add_history(line: &CStr) {
+    unsafe { readline_sys::add_history(line.as_ptr()) };
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+#[allow(dead_code)]
+pub fn add_history(line: &CStr) {
+    unimplemented!("on this platform");
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,20 @@
+#![cfg(not(test))]
+#![feature(io)]
+
+extern crate readline;
+
+use readline::readline;
+
+use std::ffi::CString;
+use std::io::Write;
+use std::io;
+
+fn main() {
+    let prompt = CString::new("user> ").unwrap();
+    let mut stdout = io::stdout();
+    while let Ok(s) = readline(&prompt) {
+        stdout.write_all(s.to_bytes()).unwrap();
+        stdout.write_all(b"\n").unwrap();
+    }
+    stdout.write_all(b"\n").unwrap();
+}

--- a/src/other.rs
+++ b/src/other.rs
@@ -1,0 +1,47 @@
+use common::Error;
+use common::error;
+
+use std::ffi::CStr;
+use std::ffi::CString;
+use std::io::BufRead;
+use std::io::Write;
+use std::io;
+use std::ops;
+
+#[allow(dead_code)]
+pub struct ReadlineBytes {
+    bytes: CString,
+}
+
+impl ops::Deref for ReadlineBytes {
+    type Target = CStr;
+    fn deref<'a>(&'a self) -> &'a CStr {
+        &self.bytes
+    }
+}
+
+#[allow(dead_code)]
+pub fn add_history(line: &CStr) {
+    let _ = line;
+}
+
+#[allow(dead_code)]
+pub fn readline_bare(prompt: &CStr) -> Result<ReadlineBytes, Error> {
+    let stdin_u = io::stdin();
+    let mut stdin = stdin_u.lock();
+
+    if let Err(_) = io::stdout().write_all(prompt.to_bytes()) {
+        return error();
+    }
+
+    let mut line = vec![];
+    if let Err(_) = stdin.read_until(b'\n', &mut line) {
+        return error();
+    }
+    line.pop(); // Take the last '\n' off the string.
+
+    Ok(ReadlineBytes { bytes: match CString::new(line) {
+        Ok(s) => s,
+        Err(_) => return error(),
+    }})
+}


### PR DESCRIPTION
This is done by taking `&CStr` instead of converting locally and returning a
newtype around a libc-allocated zero-terminated byte sequence.