### PR TITLE
Update to new extern crate semantics

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-extern crate "readline-sys" as readline_sys;
+extern crate readline_sys;
 extern crate libc;
 
 pub use common::Error;


### PR DESCRIPTION
Hyphens are not allowed in crate names anymore, and the "foo-bar" as foo_bar syntax
was removed.

Instead, cargo packages containing hyphens in their names automatically get
underscored crate names.